### PR TITLE
Add native client scaffolding and CI debug builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,30 @@
+name: Android Debug Build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: '8.2.2'
+      - name: Build debug APK
+        working-directory: clients/android
+        run: gradle :app:assembleDebug
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-debug-apk
+          path: clients/android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,34 @@
+name: iOS Debug Build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
+      - name: Build Debug Simulator App
+        working-directory: clients/ios/App
+        run: |
+          xcodebuild \
+            -scheme App \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build
+      - name: Archive build artifact
+        working-directory: clients/ios/App
+        run: |
+          cd build/Build/Products/Debug-iphonesimulator
+          zip -r App.app.zip App.app
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-debug-app
+          path: clients/ios/App/build/Build/Products/Debug-iphonesimulator/App.app.zip

--- a/clients/android/app/build.gradle.kts
+++ b/clients/android/app/build.gradle.kts
@@ -1,0 +1,74 @@
+import java.io.File
+
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.livemobile"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.livemobile.android"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        getByName("debug") {
+            val debugKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
+            storeFile = debugKeystore
+            storePassword = "android"
+            keyAlias = "AndroidDebugKey"
+            keyPassword = "android"
+        }
+    }
+
+    buildTypes {
+        getByName("debug") {
+            signingConfig = signingConfigs.getByName("debug")
+            isMinifyEnabled = false
+        }
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+
+    val cameraVersion = "1.3.1"
+    implementation("androidx.camera:camera-core:$cameraVersion")
+    implementation("androidx.camera:camera-camera2:$cameraVersion")
+    implementation("androidx.camera:camera-lifecycle:$cameraVersion")
+    implementation("androidx.camera:camera-view:1.3.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/clients/android/app/proguard-rules.pro
+++ b/clients/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# No additional rules for now.

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.livemobile">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.LiveMobile">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.LiveMobile">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/clients/android/app/src/main/java/com/example/livemobile/MainActivity.kt
+++ b/clients/android/app/src/main/java/com/example/livemobile/MainActivity.kt
@@ -1,0 +1,60 @@
+package com.example.livemobile
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.content.ContextCompat
+import com.example.livemobile.databinding.ActivityMainBinding
+
+class MainActivity : ComponentActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                startCamera()
+            } else {
+                Toast.makeText(this, R.string.camera_permission_denied, Toast.LENGTH_LONG).show()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        if (hasCameraPermission()) {
+            startCamera()
+        } else {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun hasCameraPermission(): Boolean =
+        ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder().build().apply {
+                setSurfaceProvider(binding.previewView.surfaceProvider)
+            }
+
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, preview)
+            } catch (exc: Exception) {
+                Toast.makeText(this, R.string.camera_initialization_failed, Toast.LENGTH_LONG).show()
+            }
+        }, ContextCompat.getMainExecutor(this))
+    }
+}

--- a/clients/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/clients/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M54,12a42,42 0,1 1 0,84a42,42 0,1 1 0,-84z" />
+    <path
+        android:fillColor="#6200EE"
+        android:pathData="M54,30a24,24 0,1 1 0,48a24,24 0,1 1 0,-48z" />
+</vector>

--- a/clients/android/app/src/main/res/layout/activity_main.xml
+++ b/clients/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/clients/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/clients/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/clients/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/clients/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/clients/android/app/src/main/res/values/colors.xml
+++ b/clients/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,9 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="black">#000000</color>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/clients/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/clients/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#121212</color>
+</resources>

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">Live Mobile</string>
+    <string name="camera_permission_denied">Camera permission is required to show the preview.</string>
+    <string name="camera_initialization_failed">Unable to start the camera.</string>
+</resources>

--- a/clients/android/app/src/main/res/values/themes.xml
+++ b/clients/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.LiveMobile" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/purple_700</item>
+    </style>
+</resources>

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/clients/android/gradle.properties
+++ b/clients/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true

--- a/clients/android/gradle/wrapper/gradle-wrapper.properties
+++ b/clients/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.2-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/clients/android/gradlew
+++ b/clients/android/gradlew
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER_JAR="$DIR/gradle/wrapper/gradle-wrapper.jar"
+
+if [ -f "$WRAPPER_JAR" ]; then
+  CLASSPATH="$WRAPPER_JAR"
+  exec java -Xmx64m -cp "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"
+fi
+
+if command -v gradle >/dev/null 2>&1; then
+  exec gradle "$@"
+fi
+
+echo "Gradle wrapper JAR not found and 'gradle' is not installed. Please install Gradle 8.2.2 or run this script from an environment with the wrapper jar." >&2
+exit 1

--- a/clients/android/gradlew.bat
+++ b/clients/android/gradlew.bat
@@ -1,0 +1,17 @@
+@echo off
+set DIR=%~dp0
+set CLASSPATH=%DIR%\gradle\wrapper\gradle-wrapper.jar
+
+if exist "%CLASSPATH%" (
+  java -Xmx64m -cp "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+  exit /b %errorlevel%
+)
+
+where gradle >nul 2>nul
+if %errorlevel%==0 (
+  gradle %*
+  exit /b %errorlevel%
+)
+
+echo Gradle wrapper JAR not found and Gradle is not installed. Please install Gradle 8.2.2 or provide the wrapper JAR.
+exit /b 1

--- a/clients/android/settings.gradle.kts
+++ b/clients/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "LiveMobile"
+include(":app")

--- a/clients/ios/App/App.xcodeproj/project.pbxproj
+++ b/clients/ios/App/App.xcodeproj/project.pbxproj
@@ -1,0 +1,321 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 55;
+objects = {
+
+/* Begin PBXBuildFile section */
+AA1E7F6A29F21E1200F1E0A1 /* AppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E7F5F29F21E1200F1E0A1 /* AppApp.swift */; };
+AA1E7F6B29F21E1200F1E0A1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E7F6029F21E1200F1E0A1 /* ContentView.swift */; };
+AA1E7F6C29F21E1200F1E0A1 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E7F6129F21E1200F1E0A1 /* CameraPreview.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+AA1E7F5F29F21E1200F1E0A1 /* AppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppApp.swift; sourceTree = "<group>"; };
+AA1E7F6029F21E1200F1E0A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+AA1E7F6129F21E1200F1E0A1 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
+AA1E7F6229F21E1200F1E0A1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+AA1E7F6329F21E1200F1E0A1 /* Preview Content */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Preview Content"; sourceTree = "<group>"; };
+AA1E7F6529F21E1200F1E0A1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+AA1E7F6F29F21E1200F1E0A1 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+AA1E7F5729F21E1200F1E0A1 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+AA1E7F4F29F21E1200F1E0A1 = {
+isa = PBXGroup;
+children = (
+AA1E7F5A29F21E1200F1E0A1 /* App */,
+AA1E7F6E29F21E1200F1E0A1 /* Products */,
+);
+sourceTree = "<group>";
+};
+AA1E7F5A29F21E1200F1E0A1 /* App */ = {
+isa = PBXGroup;
+children = (
+AA1E7F5F29F21E1200F1E0A1 /* AppApp.swift */,
+AA1E7F6029F21E1200F1E0A1 /* ContentView.swift */,
+AA1E7F6129F21E1200F1E0A1 /* CameraPreview.swift */,
+AA1E7F6229F21E1200F1E0A1 /* Assets.xcassets */,
+AA1E7F6329F21E1200F1E0A1 /* Preview Content */,
+AA1E7F6529F21E1200F1E0A1 /* Info.plist */,
+);
+path = App;
+sourceTree = "<group>";
+};
+AA1E7F6E29F21E1200F1E0A1 /* Products */ = {
+isa = PBXGroup;
+children = (
+AA1E7F6F29F21E1200F1E0A1 /* App.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+AA1E7F6D29F21E1200F1E0A1 /* App */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = AA1E7F7329F21E1200F1E0A1 /* Build configuration list for PBXNativeTarget "App" */;
+buildPhases = (
+AA1E7F5629F21E1200F1E0A1 /* Sources */,
+AA1E7F5729F21E1200F1E0A1 /* Frameworks */,
+AA1E7F5829F21E1200F1E0A1 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = App;
+productName = App;
+productReference = AA1E7F6F29F21E1200F1E0A1 /* App.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+AA1E7F5029F21E1200F1E0A1 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = 1;
+LastSwiftUpdateCheck = 1520;
+LastUpgradeCheck = 1520;
+TargetAttributes = {
+AA1E7F6D29F21E1200F1E0A1 = {
+CreatedOnToolsVersion = 15.2;
+};
+};
+};
+buildConfigurationList = AA1E7F5329F21E1200F1E0A1 /* Build configuration list for PBXProject "App" */;
+compatibilityVersion = "Xcode 15.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = AA1E7F4F29F21E1200F1E0A1;
+productRefGroup = AA1E7F6E29F21E1200F1E0A1 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+AA1E7F6D29F21E1200F1E0A1 /* App */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+AA1E7F5829F21E1200F1E0A1 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+AA1E7F5629F21E1200F1E0A1 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+AA1E7F6A29F21E1200F1E0A1 /* AppApp.swift in Sources */,
+AA1E7F6B29F21E1200F1E0A1 /* ContentView.swift in Sources */,
+AA1E7F6C29F21E1200F1E0A1 /* CameraPreview.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+AA1E7F7129F21E1200F1E0A1 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGNING_ALLOWED = NO;
+CODE_SIGNING_REQUIRED = NO;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+MTL_FAST_MATH = YES;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+};
+name = Debug;
+};
+AA1E7F7229F21E1200F1E0A1 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGNING_ALLOWED = NO;
+CODE_SIGNING_REQUIRED = NO;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+MTL_FAST_MATH = YES;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+VALIDATE_PRODUCT = YES;
+};
+name = Release;
+};
+AA1E7F7429F21E1200F1E0A1 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = App/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.liveMobile.app;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+AA1E7F7529F21E1200F1E0A1 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = App/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.liveMobile.app;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+AA1E7F5329F21E1200F1E0A1 /* Build configuration list for PBXProject "App" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AA1E7F7129F21E1200F1E0A1 /* Debug */,
+AA1E7F7229F21E1200F1E0A1 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Debug;
+};
+AA1E7F7329F21E1200F1E0A1 /* Build configuration list for PBXNativeTarget "App" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AA1E7F7429F21E1200F1E0A1 /* Debug */,
+AA1E7F7529F21E1200F1E0A1 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Debug;
+};
+/* End XCConfigurationList section */
+};
+rootObject = AA1E7F5029F21E1200F1E0A1 /* Project object */;
+}

--- a/clients/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/clients/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA1E7F6D29F21E1200F1E0A1"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:App.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA1E7F6D29F21E1200F1E0A1"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA1E7F6D29F21E1200F1E0A1"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/clients/ios/App/App/AppApp.swift
+++ b/clients/ios/App/App/AppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/clients/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/clients/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/ios/App/App/Assets.xcassets/Contents.json
+++ b/clients/ios/App/App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/ios/App/App/CameraPreview.swift
+++ b/clients/ios/App/App/CameraPreview.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import AVFoundation
+
+struct CameraPreview: UIViewRepresentable {
+    private let session = AVCaptureSession()
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        view.session = session
+        context.coordinator.startSession(with: session)
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator {
+        private let sessionQueue = DispatchQueue(label: "camera.session.queue")
+
+        func startSession(with session: AVCaptureSession) {
+            sessionQueue.async {
+                configure(session: session)
+                if !session.isRunning {
+                    session.startRunning()
+                }
+            }
+        }
+
+        private func configure(session: AVCaptureSession) {
+            session.beginConfiguration()
+            session.sessionPreset = .high
+
+            session.inputs.forEach { session.removeInput($0) }
+
+            guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+                  let input = try? AVCaptureDeviceInput(device: camera) else {
+                session.commitConfiguration()
+                return
+            }
+
+            if session.canAddInput(input) {
+                session.addInput(input)
+            }
+
+            let previewOutput = AVCaptureVideoDataOutput()
+            if session.canAddOutput(previewOutput) {
+                session.addOutput(previewOutput)
+            }
+
+            session.commitConfiguration()
+        }
+    }
+}
+
+final class PreviewView: UIView {
+    override class var layerClass: AnyClass {
+        AVCaptureVideoPreviewLayer.self
+    }
+
+    var videoPreviewLayer: AVCaptureVideoPreviewLayer {
+        layer as! AVCaptureVideoPreviewLayer
+    }
+
+    var session: AVCaptureSession? {
+        get { videoPreviewLayer.session }
+        set {
+            videoPreviewLayer.session = newValue
+            videoPreviewLayer.videoGravity = .resizeAspectFill
+        }
+    }
+}

--- a/clients/ios/App/App/ContentView.swift
+++ b/clients/ios/App/App/ContentView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        CameraPreview()
+            .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/clients/ios/App/App/Info.plist
+++ b/clients/ios/App/App/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDevelopmentRegion</key>
+<string>$(DEVELOPMENT_LANGUAGE)</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleName</key>
+<string>$(PRODUCT_NAME)</string>
+<key>CFBundlePackageType</key>
+<string>APPL</string>
+<key>CFBundleShortVersionString</key>
+<string>1.0</string>
+<key>CFBundleVersion</key>
+<string>1</string>
+<key>LSRequiresIPhoneOS</key>
+<true/>
+<key>UIApplicationSceneManifest</key>
+<dict>
+<key>UIApplicationSupportsMultipleScenes</key>
+<false/>
+</dict>
+<key>UIRequiredDeviceCapabilities</key>
+<array>
+<string>armv7</string>
+</array>
+<key>UISupportedInterfaceOrientations</key>
+<array>
+<string>UIInterfaceOrientationPortrait</string>
+</array>
+<key>NSCameraUsageDescription</key>
+<string>Camera access is required to preview live video.</string>
+</dict>
+</plist>

--- a/clients/ios/App/App/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/clients/ios/App/App/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,38 @@
+# Build prerequisites
+
+This repository hosts native client scaffolding for iOS and Android under the `clients/` directory. Building the debug variants relies on the following tooling:
+
+## iOS (`clients/ios/App`)
+
+* Xcode 15.2 or newer with the iOS 17 SDK.
+* CocoaPods is **not** required.
+* The project is configured for unsigned debug builds (code signing is disabled in Debug). To run on a device you will need to add your signing team identifier inside Xcode.
+
+### Build
+
+```bash
+cd clients/ios/App
+xcodebuild \
+  -scheme App \
+  -configuration Debug \
+  -sdk iphonesimulator \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath build
+```
+
+The resulting `.app` bundle can be found under `build/Build/Products/Debug-iphonesimulator/`.
+
+## Android (`clients/android`)
+
+* Java 17 JDK.
+* Gradle 8.2.2 (the provided `gradlew` script will use a locally installed Gradle if the wrapper JAR is unavailable).
+* Android SDK Platform 34 and build tools 34.0.0 or newer.
+
+### Build
+
+```bash
+cd clients/android
+./gradlew :app:assembleDebug
+```
+
+The generated APK is located at `app/build/outputs/apk/debug/app-debug.apk`.


### PR DESCRIPTION
## Summary
- scaffold a SwiftUI + AVFoundation iOS app under `clients/ios/App` with unsigned debug configuration
- add a Kotlin + CameraX Android app under `clients/android` with Gradle settings for debug signing
- document build prerequisites and add CI workflows that build and upload debug artifacts

## Testing
- not run (infrastructure only)


------
https://chatgpt.com/codex/tasks/task_e_68d8c5e8e1c4832ebf8932958eb9f491