### PR TITLE
Fix strong capture in CameraPreview session queue

### DIFF
--- a/clients/ios/App/App/CameraPreview.swift
+++ b/clients/ios/App/App/CameraPreview.swift
@@ -22,8 +22,8 @@ struct CameraPreview: UIViewRepresentable {
         private let sessionQueue = DispatchQueue(label: "camera.session.queue")
 
         func startSession(with session: AVCaptureSession) {
-            sessionQueue.async {
-                configure(session: session)
+            sessionQueue.async { [self] in
+                self.configure(session: session)
                 if !session.isRunning {
                     session.startRunning()
                 }


### PR DESCRIPTION
## Summary
- capture the coordinator explicitly inside the session queue closure to silence Swift warnings about implicit self usage

## Testing
- xcodebuild -version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da1d77e500832e9a431a239ba004cc